### PR TITLE
Reminder endpoint

### DIFF
--- a/src/impl/Event/router_v1.py
+++ b/src/impl/Event/router_v1.py
@@ -380,8 +380,8 @@ def resend_accept_mail(
 
 
 @router.get("/{event_id}/send_slack_mail/")
-def send_slack_mail(event_id: int, token: BaseToken = Depends(JWTBearer())):
-    event_service.send_slack_mail(event_id, token)
+def send_slack_mail(event_id: int, slackUrl: str, token: BaseToken = Depends(JWTBearer())):
+    event_service.send_slack_mail(event_id, slackUrl, token)
     return {"success": True}
 
 

--- a/src/impl/Event/router_v1.py
+++ b/src/impl/Event/router_v1.py
@@ -379,9 +379,20 @@ def resend_accept_mail(
     return {"success": True}
 
 
-@router.get("/{event_id}/send_slack_mail/")
+@router.post("/{event_id}/send_slack_mail/")
 def send_slack_mail(event_id: int, slackUrl: str, token: BaseToken = Depends(JWTBearer())):
     event_service.send_slack_mail(event_id, slackUrl, token)
+    return {"success": True}
+
+@router.post("/{event_id}/send_reminder_mails/")
+def send_reminder_mails(
+    event_id: int,
+    token: BaseToken = Depends(JWTBearer()),
+):
+    """
+    Send reminder mails to all accepted hackers of an event
+    """
+    event_service.send_reminder_mails(event_id, token)
     return {"success": True}
 
 

--- a/src/impl/Event/service.py
+++ b/src/impl/Event/service.py
@@ -972,7 +972,7 @@ class EventService(BaseService):
         db.session.commit()
 
     @BaseService.needs_service(MailClient)
-    def send_slack_mail(self, event_id: int, data: BaseToken):
+    def send_slack_mail(self, event_id: int, slackUrl: str, data: BaseToken):
         if not data.check([UserType.LLEIDAHACKER]):
             raise AuthenticationException("Not authorized")
         event = self.get_by_id(event_id)
@@ -992,7 +992,7 @@ class EventService(BaseService):
                     subject="HackEPS2024 slack invitation",
                     receiver_id=str(hacker.id),
                     receiver_mail=str(hacker.email),
-                    fields="https://join.slack.com/t/hackeps2024/shared_invite/zt-2usc9qny9-z3NkybNlCXFAI9m0Cl~FsQ",
+                    fields=slackUrl,
                 )
             )
 

--- a/src/impl/Event/service.py
+++ b/src/impl/Event/service.py
@@ -1038,8 +1038,7 @@ class EventService(BaseService):
             except Exception:
                 days_left = 0
 
-            # fields expected: name, days_left, token, event_name
-            fields = f"{hacker.name},{days_left},{reg.confirm_assistance_token},{event.name}"
+            fields = f"{hacker.name},{event.name},{days_left},{reg.confirm_assistance_token}"
 
             mail = self.mail_client.create_mail(
                 MailCreate(

--- a/src/impl/Event/service.py
+++ b/src/impl/Event/service.py
@@ -984,7 +984,7 @@ class EventService(BaseService):
         hackers = event.accepted_hackers
 
         for hacker in hackers:
-            self.mail_client.create_mail(
+            mail = self.mail_client.create_mail(
                 MailCreate(
                     template_id=self.mail_client.get_internall_template_id(
                         InternalTemplate.EVENT_SLACK_INVITE
@@ -995,6 +995,8 @@ class EventService(BaseService):
                     fields=slackUrl,
                 )
             )
+            # send the created mail
+            self.mail_client.send_mail_by_id(mail.id)
 
         db.session.commit()
 

--- a/src/impl/Mail/internall_templates.py
+++ b/src/impl/Mail/internall_templates.py
@@ -11,5 +11,7 @@ class InternalTemplate(Enum):
 
     EVENT_HACKER_REGISTERED = "event_hacker_registered"
     EVENT_HACKER_ACCEPTED = "event_hacker_accepted"
+
+    EVENT_HACKER_REMINDER = "event_hacker_reminder"
     # EVENT_HACKER_REJECTED = 'event_hacker_accepted'
     # EVENT_HACKER_CONFIRMATION = 'event_hacker_confirmation'


### PR DESCRIPTION
This pull request adds new functionality for sending reminder emails to event participants and improves the process for sending Slack invitations. The main changes include introducing a new endpoint and service method for sending reminder emails to accepted hackers, updating the Slack invitation endpoint to accept a dynamic URL, and adding a new internal mail template for reminders.

**New reminder email functionality:**

* Added a new POST endpoint `/{event_id}/send_reminder_mails/` in `router_v1.py` to trigger sending reminder emails to all accepted hackers of an event.
* Implemented `send_reminder_mails` service method in `Event/service.py` to send reminder emails only to hackers who have not yet confirmed attendance, generating a confirmation token if needed and including days left until the event.
* Introduced a new internal mail template `EVENT_HACKER_REMINDER` in `Mail/internall_templates.py` for the reminder emails.

**Slack invitation improvements:**

* Changed the Slack invitation endpoint from GET to POST and added a `slackUrl` parameter, allowing dynamic Slack invite links to be sent.
* Updated the `send_slack_mail` service method to accept the `slackUrl` parameter and use it in the invitation email. [[1]](diffhunk://#diff-59189f264ed366cf7a26116fd415f0a28423954a3e423e561be0684c4c17e8f0L975-R975) [[2]](diffhunk://#diff-59189f264ed366cf7a26116fd415f0a28423954a3e423e561be0684c4c17e8f0L987-R1057)